### PR TITLE
AUTO apps: remove senseless code & unnecesary path checking

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -513,7 +513,6 @@ int main(int argc, char *argv[])
     }
     DPRINTF("Wait time consummed. running AUTO entry\n");
     TimerEnd();
-    scr_clear();
     for (j = 0; j < 3; j++) {
         EXECPATHS[j] = CheckPath(GLOBCFG.KEYPATHS[0][j]);
         if (exist(EXECPATHS[j])) {
@@ -528,7 +527,7 @@ int main(int argc, char *argv[])
             scr_setfontcolor(0xffffff);
         }
     }
-
+    scr_clear();
     scr_setfontcolor(0x00ffff);
     scr_printf("\n\n\tEND OF EXECUTION REACHED\nCould not find any of the default applications\nCheck your config file for the LK_AUTO_E# entries\nOr press a key while logo displays to run the bound application\npress R1+START to enter emergency mode");
     scr_setfontcolor(0xffffff);

--- a/src/main.c
+++ b/src/main.c
@@ -522,11 +522,10 @@ int main(int argc, char *argv[])
                 PadDeinitPads();
             RunLoaderElf(EXECPATHS[j], MPART);
         } else {
-            scr_setfontcolor(0x00ffff);
             DPRINTF("%s not found\n", EXECPATHS[j]);
-            scr_setfontcolor(0xffffff);
         }
     }
+
     scr_clear();
     scr_setfontcolor(0x00ffff);
     scr_printf("\n\n\tEND OF EXECUTION REACHED\nCould not find any of the default applications\nCheck your config file for the LK_AUTO_E# entries\nOr press a key while logo displays to run the bound application\npress R1+START to enter emergency mode");

--- a/src/main.c
+++ b/src/main.c
@@ -512,24 +512,22 @@ int main(int argc, char *argv[])
         }
     }
     DPRINTF("Wait time consummed. running AUTO entry\n");
-    tstart = Timer();
-    if (Timer() <= (tstart + 4000)) {
-        scr_clear();
-        for (j = 0; j < 3; j++) {
-            if (exist(CheckPath(GLOBCFG.KEYPATHS[0][j]))) {
-                scr_setfontcolor(0x00ff00);
-                scr_printf("\tLoading %s\n", GLOBCFG.KEYPATHS[0][j]);
-                if (!is_PCMCIA)
-                    PadDeinitPads();
-                RunLoaderElf(CheckPath(GLOBCFG.KEYPATHS[0][j]), MPART);
-            } else {
-                scr_setfontcolor(0x00ffff);
-                DPRINTF("%s not found\n", GLOBCFG.KEYPATHS[0][j]);
-                scr_setfontcolor(0xffffff);
-            }
+    TimerEnd();
+    scr_clear();
+    for (j = 0; j < 3; j++) {
+        EXECPATHS[j] = CheckPath(GLOBCFG.KEYPATHS[0][j]);
+        if (exist(EXECPATHS[j])) {
+            scr_setfontcolor(0x00ff00);
+            scr_printf("\tLoading %s\n", EXECPATHS[j]);
+            if (!is_PCMCIA)
+                PadDeinitPads();
+            RunLoaderElf(EXECPATHS[j], MPART);
+        } else {
+            scr_setfontcolor(0x00ffff);
+            DPRINTF("%s not found\n", EXECPATHS[j]);
+            scr_setfontcolor(0xffffff);
         }
     }
-    TimerEnd();
 
     scr_setfontcolor(0x00ffff);
     scr_printf("\n\n\tEND OF EXECUTION REACHED\nCould not find any of the default applications\nCheck your config file for the LK_AUTO_E# entries\nOr press a key while logo displays to run the bound application\npress R1+START to enter emergency mode");


### PR DESCRIPTION
im not sure why I added that senseless check (`if (Timer() <= (tstart + 4000)) {`) it will always evaluate true...

also, using a temporary var (`EXECPATHS[j]`) avoids mounting HDD partitions twice