### PR TITLE
optimize config reading and add IRX Loading feature

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -436,12 +436,14 @@ int main(int argc, char *argv[])
                         GLOBCFG.TRAYEJECT = atoi(value);
                         continue;
                     }
-                    for (x = 0; x < 17; x++) {
-                        for (j = 0; j < 3; j++) {
-                            sprintf(TMP, "LK_%s_E%d", KEYS_ID[x], j + 1);
-                            if (!strcmp(name, TMP)) {
-                                GLOBCFG.KEYPATHS[x][j] = value;
-                                break;
+                    if (!strncmp("LK_", name, 3)) {
+                        for (x = 0; x < 17; x++) {
+                            for (j = 0; j < 3; j++) {
+                                sprintf(TMP, "LK_%s_E%d", KEYS_ID[x], j + 1);
+                                if (!strcmp(name, TMP)) {
+                                    GLOBCFG.KEYPATHS[x][j] = value;
+                                    break;
+                                }
                             }
                         }
                     }

--- a/src/main.c
+++ b/src/main.c
@@ -419,6 +419,11 @@ int main(int argc, char *argv[])
                         GLOBCFG.OSDHISTORY_READ = atoi(value);
                         continue;
                     }
+                    if (!strncmp("LOAD_IRX_E", name, 10)) {
+                        j = SifLoadStartModule(CheckPath(value), 0, NULL, &x);
+                        DPRINTF("# Loaded IRX from config entry [%s] -> [%s]: ret=%d, ID=%d\n", name, value, j, x);
+                        continue;
+                    }
                     if (!strcmp("SKIP_PS2LOGO", name)) {
                         GLOBCFG.SKIPLOGO = atoi(value);
                         continue;


### PR DESCRIPTION
Any config item wich starts with `LOAD_IRX_E` (eg: `LOAD_IRX_E1`) will make PS2BBL try to load an IRX module from the path specified by this config entry

Also, launch keys parsing is only performed if entry starts with `LK_` (useful Only if config has text unrecognizable by PS2BBL, because launch key processing is done at the end)