### PR TITLE
Pass complete BOOT2 to PS2LOGO

### DIFF
--- a/src/ps2.c
+++ b/src/ps2.c
@@ -296,7 +296,7 @@ int PS2DiscBoot(int skip_PS2LOGO)
         BootError();
     }
 
-    args[0] = ps2disc_boot;
+    args[0] = line;
 
 
     DPRINTF("%s updating play history\n", __func__);


### PR DESCRIPTION
On my SCPH-50004 with BIOS 1.9 this matches the behavior of OSDSYS.

Also tested working on an SCPH-30000 BIOS in PCSX2, as well as a real SCPH-75004.