### PR TITLE
Reset XPARAM to default state on boot

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include <loadfile.h>
 #include <debug.h>
 #include <iopcontrol.h>
+#include <iop_regs.h>
 #include <iopheap.h>
 #include <sbv_patches.h>
 #include <ps2sdkapi.h>
@@ -190,6 +191,26 @@ int main(int argc, char *argv[])
     static int num_buttons = 4, pad_button = 0x0100; // first pad button is L2
     unsigned char *RAM_p = NULL;
     char *CNFBUFF, *name, *value;
+
+#ifndef NO_DECKARD
+#define XPARAM_PARAM_ADDR *((uint32_t *)0xFFFE01A0)
+#define XPARAM_VALUE_ADDR *((uint32_t *)0xFFFE01A4)
+    if (IOP_CPU_TYPE == IOP_TYPE_POWERPC) { // this PS2 is DECKARD. reset the XPARAMS to their default value in case we are not coming from a reset
+        const u32 xparam_default[0x12] = {
+            0x01F4, 0x07D0, 0x0023, 0x07D0,
+            0x0014, 0x0000, 0x0001, 0x0020,
+            0x0000, 0x0000, 0x0000, 0x0000,
+            0x0000, 0x229C, 0x06EC, 0x06EC,
+            0x0001, 0x0090
+        };
+        for (x = 0; x < 0x12; x++) {
+            XPARAM_PARAM_ADDR = 0xFFFFFFFF;
+            XPARAM_VALUE_ADDR = 0x0;
+            XPARAM_PARAM_ADDR = x;
+            XPARAM_VALUE_ADDR = xparam_default[x];
+        }
+    }
+#endif
 
     ResetIOP();
     SifInitIopHeap(); // Initialize SIF services for loading modules and files.


### PR DESCRIPTION
intended for IGR and other stuffs that dont reset the DECKARD but makes the console run bootloader again