### PR TITLE
Add support for using ata_bd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ PSX ?= 0 # PSX DESR support
 HDD ?= 0 #wether to add internal HDD support
 MMCE ?= 0
 MX4SIO ?= 0
+HDD_BD ?= 0 # use ata_bd instead of ps2atad for HDD support
 PROHBIT_DVD_0100 ?= 0 # prohibit the DVD Players v1.00 and v1.01 from being booted.
 XCDVD_READKEY ?= 0 # Enable the newer sceCdReadKey checks, which are only supported by a newer CDVDMAN module.
 UDPTTY ?= 0 # printf over UDP
@@ -100,6 +101,25 @@ ifeq ($(MMCE), 1)
   endif
 endif
 
+ifeq ($(HDD), 1)
+  $(info --- compiling with HDD support)
+  ifeq ($(HDD_BD), 1)
+    # This needs homebrew SIO2MAN
+    HOMEBREW_IRX = 1
+    EE_OBJS += ata_bd_irx.o
+    EE_CFLAGS += -DHDD_BD
+  else
+    EE_OBJS += ps2atad_irx.o
+  endif
+
+  EE_LIBS += -lpoweroff
+  EE_OBJS += ps2fs_irx.o ps2hdd_irx.o poweroff_irx.o
+  EE_CFLAGS += -DHDD
+  FILEXIO_NEED = 1
+  DEV9_NEED = 1
+  KELFTYPE = HDD
+endif
+
 ifeq ($(HOMEBREW_IRX), 1)
    $(info --- enforcing usage of homebrew IRX modules)
    USE_ROM_PADMAN = 0
@@ -159,16 +179,6 @@ ifeq ($(HAS_EMBED_IRX), 1)
   EE_CFLAGS += -DHAS_EMBEDDED_IRX
 else
   $(info --- USB drivers will be external)
-endif
-
-ifeq ($(HDD), 1)
-  $(info --- compiling with HDD support)
-  EE_LIBS += -lpoweroff
-  EE_OBJS += ps2fs_irx.o ps2hdd_irx.o ps2atad_irx.o poweroff_irx.o
-  EE_CFLAGS += -DHDD
-  FILEXIO_NEED = 1
-  DEV9_NEED = 1
-  KELFTYPE = HDD
 endif
 
 ifeq ($(UDPTTY), 1)

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,6 @@ endif
 ifeq ($(HDD), 1)
   $(info --- compiling with HDD support)
   ifeq ($(HDD_BD), 1)
-    # This needs homebrew SIO2MAN
-    HOMEBREW_IRX = 1
     EE_OBJS += ata_bd_irx.o
     EE_CFLAGS += -DHDD_BD
   else

--- a/include/common.h
+++ b/include/common.h
@@ -5,7 +5,7 @@ enum
     SOURCE_MC0 = 0,
     SOURCE_MC1,
     SOURCE_MASS,
-#ifdef MX4SIO
+#if defined(MX4SIO) || defined(HDD_BD)
     SOURCE_MX4SIO,
 #endif
 #ifdef HDD
@@ -30,7 +30,7 @@ char *CONFIG_PATHS[SOURCE_COUNT] = {
     "mc0:/SYS-CONF/PS2BBL.INI",
     "mc1:/SYS-CONF/PS2BBL.INI",
     "mass:/PS2BBL/CONFIG.INI",
-#ifdef MX4SIO
+#if defined(MX4SIO) || defined(HDD_BD)
     "massX:/PS2BBL/CONFIG.INI",
 #endif
 #ifdef HDD

--- a/include/common.h
+++ b/include/common.h
@@ -5,8 +5,11 @@ enum
     SOURCE_MC0 = 0,
     SOURCE_MC1,
     SOURCE_MASS,
-#if defined(MX4SIO) || defined(HDD_BD)
+#ifdef MX4SIO
     SOURCE_MX4SIO,
+#endif
+#ifdef HDD_BD
+    SOURCE_HDD_BD,
 #endif
 #ifdef HDD
     SOURCE_HDD,
@@ -30,8 +33,11 @@ char *CONFIG_PATHS[SOURCE_COUNT] = {
     "mc0:/SYS-CONF/PS2BBL.INI",
     "mc1:/SYS-CONF/PS2BBL.INI",
     "mass:/PS2BBL/CONFIG.INI",
-#if defined(MX4SIO) || defined(HDD_BD)
+#ifdef MX4SIO
     "massX:/PS2BBL/CONFIG.INI",
+#endif
+#ifdef HDD_BD
+    "massH:/PS2BBL/CONFIG.INI",
 #endif
 #ifdef HDD
     "hdd0:__sysconf:pfs:/PS2BBL/CONFIG.INI",
@@ -56,6 +62,9 @@ static const char *SOURCES[SOURCE_COUNT] = {
     "usb",
 #ifdef MX4SIO
     "mx4sio",
+#endif
+#ifdef HDD_BD
+    "hdd_bd",
 #endif
 #ifdef HDD
     "hdd",

--- a/include/irx_import.h
+++ b/include/irx_import.h
@@ -26,7 +26,14 @@ IMPORT_BIN2C(fileXio_irx);
 
 #ifdef HDD
 IMPORT_BIN2C(poweroff_irx);
+#ifdef HDD_BD
+#ifdef USE_ROM_SIO2MAN
+#error HDD_BD needs Homebrew SIO2MAN to work
+#endif
+IMPORT_BIN2C(ata_bd_irx);
+#else
 IMPORT_BIN2C(ps2atad_irx);
+#endif
 IMPORT_BIN2C(ps2hdd_irx);
 IMPORT_BIN2C(ps2fs_irx);
 #endif

--- a/include/irx_import.h
+++ b/include/irx_import.h
@@ -27,9 +27,6 @@ IMPORT_BIN2C(fileXio_irx);
 #ifdef HDD
 IMPORT_BIN2C(poweroff_irx);
 #ifdef HDD_BD
-#ifdef USE_ROM_SIO2MAN
-#error HDD_BD needs Homebrew SIO2MAN to work
-#endif
 IMPORT_BIN2C(ata_bd_irx);
 #else
 IMPORT_BIN2C(ps2atad_irx);

--- a/include/main.h
+++ b/include/main.h
@@ -115,7 +115,7 @@ void poweroffCallback(void *arg);
 #endif
 
 #if defined(MX4SIO) || defined(HDD_BD)
-int LookForBDMDevice(void);
+int LookForBDMDevice(char *driver_name);
 #endif
 
 #ifdef FILEXIO

--- a/include/main.h
+++ b/include/main.h
@@ -114,7 +114,7 @@ void poweroffCallback(void *arg);
 #define MPART NULL
 #endif
 
-#ifdef MX4SIO
+#if defined(MX4SIO) || defined(HDD_BD)
 int LookForBDMDevice(void);
 #endif
 

--- a/src/elf.c
+++ b/src/elf.c
@@ -17,7 +17,7 @@
 void RunLoaderElf(const char *filename, const char *party)
 {
     DPRINTF("%s\n", __FUNCTION__);
-    if (party == NULL) {
+    if (party == NULL || strlen(party) == 0) {
         DPRINTF("LoadELFFromFile(%s, 0, NULL)\n", filename);
         DBGWAIT(2);
         LoadELFFromFile(filename, 0, NULL);

--- a/src/elf.c
+++ b/src/elf.c
@@ -17,7 +17,7 @@
 void RunLoaderElf(const char *filename, const char *party)
 {
     DPRINTF("%s\n", __FUNCTION__);
-    if (party == NULL || strlen(party) == 0) {
+    if (party == NULL || strnlen(party, 2) == 0) {
         DPRINTF("LoadELFFromFile(%s, 0, NULL)\n", filename);
         DBGWAIT(2);
         LoadELFFromFile(filename, 0, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -478,10 +478,10 @@ char *CheckPath(char *path)
         int x = LookForBDMDevice();
         if (x >= 0) {
             path[4] = '0' + x;
-            if (PART != NULL) {
-                // Neither device type needs the partition name.
-                PART[0] = '\0';
-            }
+#ifdef HDD
+            // Neither device type needs the partition name.
+            MPART[0] = '\0';
+#endif
         }
 #endif
     }


### PR DESCRIPTION
Switching to ata_bd allows for usage of files on exFAT partitions on the internal HDD. This covers both the PS2BBL configuration file, and any referenced programs to be launched.

This functionality is enabled when built with: HDD=1 HDD_BD=1

Toward #68 